### PR TITLE
Use scheme from lastURL if missing scheme

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -538,6 +538,8 @@ proc getNewLocation(lastURL: Uri, headers: HttpHeaders): Uri =
     result.anchor = parsedLocation.anchor
   else:
     result = parsedLocation
+  if result.scheme == "":
+    result.scheme = lastURL.scheme
 
 proc generateHeaders(requestUrl: Uri, httpMethod: HttpMethod, headers: HttpHeaders,
                      proxy: Proxy): string =


### PR DESCRIPTION
When a Location: header has a url that has a relative scheme (Location: //example.com/) the resulting scheme can default to the same scheme being used from lastURL.